### PR TITLE
Refactored PacketForwarderSimulator

### DIFF
--- a/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
+++ b/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
@@ -29,7 +29,7 @@ namespace AESDemo
             
             byte[] messageraw = leadingByte.Concat(Encoding.Default.GetBytes(inputJson)).ToArray();
             LoRaMessage message = new LoRaMessage(messageraw);
-            Console.WriteLine("decrypted "+(message.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C"));
+            Console.WriteLine("decrypted "+(message.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
             Console.WriteLine("mic is valid: "+message.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
             Console.Read();
         }

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/PacketForwarderSimulator.csproj
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/PacketForwarderSimulator.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\LoraTools\LoRaTools.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/PacketForwarderSimulator.csproj
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/PacketForwarderSimulator.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\LoraTools\LoRaTools.csproj" />
   </ItemGroup>
 

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
@@ -1,15 +1,78 @@
-﻿using System;
+﻿using Mono.Options;
+using System;
+using System.Collections.Generic;
+
 
 namespace Simulator
 {
     class Program
     {
-        //Original IP: 10.0.28.34
         static void Main(string[] args)
         {
+            //
+            // Setup default parameter values.
+            //
             string ip = "127.0.0.1";
             int port = 1680;
+            bool showHelp = false;
 
+            //
+            // Parse command-line arguments.
+            //
+            var ipHelp = String.Format("udp packets will be sent to this ip address (defaults to {0})", ip);
+            var portHelp = String.Format("udp packets will be sent to this port (defaults to {0})", port);
+
+            var options = new OptionSet {
+                { "i|ip=", ipHelp, arg => ip = arg },
+                { "p|port=", portHelp, (int arg) => port = arg },
+                { "h|help", "show this message and exit", arg => showHelp = arg != null },
+            };
+
+            List<string> extra;
+            try
+            {
+                // parse the command line
+                extra = options.Parse(args);
+                if (extra.Count > 0)
+                {
+                    throw new OptionException("Invalid option", extra[0]);
+                }
+            }
+            catch (OptionException e)
+            {
+                // Print error message
+                var name = String.Format("{0}", System.AppDomain.CurrentDomain.FriendlyName);
+                Console.Write(String.Format("{0}: ", name));
+                Console.WriteLine(e.Message);
+                Console.WriteLine(
+                    String.Format("Try `dotnet {0}.dll --help' for more information.",
+                                  name));
+
+                // TODO: return error code here.
+                return;
+            }
+
+            if (showHelp)
+            {
+                Console.WriteLine("Options:");
+                options.WriteOptionDescriptions(Console.Out);
+
+                // TODO: return error code here.
+                return;
+            }
+
+            //
+            // Run the Read-Eval-Print-Loop (REPL).
+            //
+            REPL(ip, port);
+        }
+
+
+        static void REPL(string ip, int port)
+        {
+            //
+            // Run the Read-Eval-Print-Loop (REPL).
+            //
             Console.WriteLine("Welcome to the PacketForwarder Simulator");
             Console.WriteLine(String.Format("Broadcasting to {0}, port {1}.", ip, port));
             Console.WriteLine("");
@@ -30,6 +93,8 @@ namespace Simulator
                 // Exit on blank line.
                 if (line.Length == 0)
                 {
+                    Console.WriteLine("bye");
+                    Console.WriteLine("");
                     break;
                 }
 

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
@@ -21,6 +21,8 @@ namespace Simulator
                               LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
             Console.WriteLine("");
 
+            LoRaTools.PacketForwarder forwarder = new LoRaTools.PacketForwarder(ip, port);
+
             while (true)
             {
                 Console.Write("packet? ");
@@ -40,9 +42,7 @@ namespace Simulator
                         var packet = LoRaTools.PrerecordedPackets.GetPacket(n);
                         var rawBytes = packet.GetRawWireBytes();
 
-                        UdpClient udpConnection = new UdpClient();
-                        IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Parse(ip), port);
-                        udpConnection.Send(rawBytes, rawBytes.Length, ipEndPoint);
+                        forwarder.Send(rawBytes);
 
                         Console.WriteLine(String.Format("  broadcast packet {0}", n));
                     }

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
@@ -1,35 +1,62 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
+
 
 namespace Simulator
 {
     class Program
     {
-        public static byte[] StringToByteArray(string hex)
-        {
-            return Enumerable.Range(0, hex.Length)
-                             .Where(x => x % 2 == 0)
-                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
-                             .ToArray();
-        }
-
         //Original IP: 10.0.28.34
         static void Main(string[] args)
         {
-            Console.WriteLine("Simulator starting now. Press 'Enter' to generate message.");
+            string ip = "127.0.0.1";
+            int port = 1680;
+
+            Console.WriteLine("Welcome to the PacketForwarder Simulator");
+            Console.WriteLine(String.Format("Broadcasting to {0}, port {1}.", ip, port));
+            Console.WriteLine("");
+            Console.WriteLine(
+                String.Format("Enter packet number in the range 0..{0} or a blank line to quit.",
+                              LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
+            Console.WriteLine("");
+
             while (true)
             {
-                byte[] leadingByte = StringToByteArray("0205DB00AA555A0000000101");
-                string inputJson = "{\"rxpk\":[{\"tmst\":3121882787,\"chan\":2,\"rfch\":1,\"freq\":868.500000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":7.0,\"rssi\":-16,\"size\":20,\"data\":\"QEa5KACANwAIXiRAODD6gSCHMSk=\"}]}";
-                byte[] message = leadingByte.Concat(Encoding.Default.GetBytes(inputJson)).ToArray();
-                UdpClient udpConnection = new UdpClient();
-                IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1680);
-                udpConnection.Send(message, message.Length, ipEndPoint);
-                //System.Threading.Thread.Sleep(1000);
-                Console.ReadLine();
+                Console.Write("packet? ");
+                Console.Out.Flush();            // TODO: REVIEW: flush not required on Windows. Check on Linux.
+                var line = Console.ReadLine();
+
+                if (line.Length == 0)
+                {
+                    break;
+                }
+
+                Int32 n = 0;
+                if (Int32.TryParse(line, out n))
+                {
+                    try
+                    {
+                        var packet = LoRaTools.PrerecordedPackets.GetPacket(n);
+                        var rawBytes = packet.GetRawWireBytes();
+
+                        UdpClient udpConnection = new UdpClient();
+                        IPEndPoint ipEndPoint = new IPEndPoint(IPAddress.Parse(ip), port);
+                        udpConnection.Send(rawBytes, rawBytes.Length, ipEndPoint);
+
+                        Console.WriteLine(String.Format("  broadcast packet {0}", n));
+                    }
+                    catch (System.ArgumentException e)
+                    {
+                        Console.WriteLine("Invalid packet number.");
+                        Console.WriteLine(
+                            String.Format("Enter packet number in the range 0..{0} or a blank line to quit.",
+                                          LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
+                        Console.WriteLine("");
+                    }
+
+                    // TODO: catch and handle other errors here? At least set return code on failure.
+                }
             }
         }
     }

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Net;
-using System.Net.Sockets;
-
 
 namespace Simulator
 {
@@ -17,7 +14,7 @@ namespace Simulator
             Console.WriteLine(String.Format("Broadcasting to {0}, port {1}.", ip, port));
             Console.WriteLine("");
             Console.WriteLine(
-                String.Format("Enter packet number in the range 0..{0} or a blank line to quit.",
+                String.Format("Enter verbatim packet text, a packet number in the range 0..{0} or a blank line to exit.",
                               LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
             Console.WriteLine("");
 
@@ -25,39 +22,74 @@ namespace Simulator
 
             while (true)
             {
+                // Prompt for packet text.
                 Console.Write("packet? ");
                 Console.Out.Flush();            // TODO: REVIEW: flush not required on Windows. Check on Linux.
                 var line = Console.ReadLine();
 
+                // Exit on blank line.
                 if (line.Length == 0)
                 {
                     break;
                 }
 
-                Int32 n = 0;
-                if (Int32.TryParse(line, out n))
+                // Otherwise, try to determine which packet to broadcast.
+
+                LoRaTools.IPacket packet = null;
+
+                if (LoRaTools.PacketValidator.IsLikelyValidLoRaWanPacket(line))
                 {
-                    try
-                    {
-                        var packet = LoRaTools.PrerecordedPackets.GetPacket(n);
-                        var rawBytes = packet.GetRawWireBytes();
-
-                        forwarder.Send(rawBytes);
-
-                        Console.WriteLine(String.Format("  broadcast packet {0}", n));
-                    }
-                    catch (System.ArgumentException e)
-                    {
-                        Console.WriteLine("Invalid packet number.");
-                        Console.WriteLine(
-                            String.Format("Enter packet number in the range 0..{0} or a blank line to quit.",
-                                          LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
-                        Console.WriteLine("");
-                    }
-
-                    // TODO: catch and handle other errors here? At least set return code on failure.
+                    // Input line represents complete text of the packet.
+                    // Just build the packet from the input text.
+                    packet = new LoRaTools.RecordedPacket(line);
+                    Console.WriteLine("  ... broadcasting verbatim packet");
                 }
+                else
+                {
+                    Int32 n = 0;
+                    if (Int32.TryParse(line, out n))
+                    {
+                        if (n >= 0 && n < LoRaTools.PrerecordedPackets.GetPacketCount())
+                        {
+                            // Input line represents a valid pre-recorded packet number.
+                            // Look up the pre-recorded packet.
+                            packet = LoRaTools.PrerecordedPackets.GetPacket(n);
+                            Console.WriteLine(String.Format("  ... broadcasting pre-recorded packet {0}.", n));
+                        }
+                    }
+                }
+
+                if (packet != null)
+                {
+                    // We have a packet. Broadcast it.
+                    forwarder.Send(packet);
+
+                    // TODO: REVIEW: should we print out or log the raw packet
+                    // text here for diagnostic purposes.
+                }
+                else
+                {
+                    // We couldn't figure out which packet was requested.
+                    // Print help message.
+                    Console.WriteLine("Invalid packet.");
+                    PrintREPLHelp();
+                }
+
+                // TODO: catch and handle other errors here? At least set return code on failure.
             }
+        }
+
+
+        static void PrintREPLHelp()
+        {
+            Console.WriteLine("Valid options include");
+            Console.WriteLine("  Complete LoRaWan packet text, starting with 24 hex digits");
+            Console.WriteLine("     followed by JSON parameters and payload.");
+            Console.WriteLine(
+                String.Format("  Pre-recorded packet number in the range 0..{0}",
+                                LoRaTools.PrerecordedPackets.GetPacketCount() - 1));
+            Console.WriteLine("  Blank line to exit");
+            Console.WriteLine("");
         }
     }
 }

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/README.md
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/README.md
@@ -1,10 +1,19 @@
 # Packet Forwarder Simulator
 
 Diagnostic tool that broadcasts LoRaWAN UDP packets to host ip and port specified on the command line.
-(**NOTE:** Currently the application is hard-coded to broadcast to port `1680` at `127.0.0.1`. Command-line parameters comming soon!)
+Sample usage:
 
+~~~
+% dotnet PacketForwarderSimulator.dll --help
+Options:
+  -i, --ip=VALUE             udp packets will be sent to this ip address (
+                               defaults to 127.0.0.1)
+  -p, --port=VALUE           udp packets will be sent to this port (defaults to
+                               1680)
+  -h, --help                 show this message and exit
+~~~
 
-The tool starts a Read-Eval-Print-Loop that broadcasts packets. The loop can be driven interactively during debugging sessions or it can be used in conjunction with stream redirection for unattended operation as part of test suites.
+The tool starts a _Read-Eval-Print-Loop_ (REPL) that broadcasts packets in response to user commands. The loop can be driven interactively during debugging sessions or it can be used in conjunction with stream redirection for unattended operation as part of test suites.
 
 All simulator functionality exposed in the command-line tool is also available as library calls for use by automated tests.
 
@@ -32,10 +41,10 @@ Legal REPL operations include
 
 * **Blank Line.** Exits the application.
 
-Here's a sample transcript:
+Here's a sample session transcript:
 
 ~~~
-% PacketForwarderSimulator
+% dotnet PacketForwarderSimulator.dll
 
 Welcome to the PacketForwarder Simulator
 Broadcasting to 127.0.0.1, port 1680.
@@ -47,5 +56,7 @@ packet? 1
 packet? 0205DB00AA555A0000000101{"rxpk":[{ "tmst":2166390139,"chan":0,"rfch":1,"freq":868.100000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":9.5,"rssi":-24,"size":18,"data":"QEa5KADAQwAIwahYNa9zWAn1"}]}
   ... broadcasting verbatim packet
 packet?
-Press any key to continue . . .
+bye
+
+%
 ~~~

--- a/LoRaEngine/DevTools/PacketForwarderSimulator/README.md
+++ b/LoRaEngine/DevTools/PacketForwarderSimulator/README.md
@@ -1,8 +1,51 @@
 # Packet Forwarder Simulator
 
-Command line tool that broadcasts recorded LoRa UDP packets to host and port specified on the command line.
+Diagnostic tool that broadcasts LoRaWAN UDP packets to host ip and port specified on the command line.
+(**NOTE:** Currently the application is hard-coded to broadcast to port `1680` at `127.0.0.1`. Command-line parameters comming soon!)
 
-Currently plays back two recorded packets two times. The second playback is used to test frame duplication scenarios.
 
-Message sent will be like (gatewayinfo|jsonpayload) where gatewayinfo is a sequence of bytes taken from a LoRa Payload. The jsonpayload can be edited on the inputJson variable.
-Put the url/port of your udp listener in line 29.
+The tool starts a Read-Eval-Print-Loop that broadcasts packets. The loop can be driven interactively during debugging sessions or it can be used in conjunction with stream redirection for unattended operation as part of test suites.
+
+All simulator functionality exposed in the command-line tool is also available as library calls for use by automated tests.
+
+Legal REPL operations include
+* **Broadcast a pre-recorded packet.** Currently the system supports three pre-recorded packets which can be selected by typing `0`, `1`, or `2`. Packet details follow:
+
+        /// Packets 0, 1, and 2 form a sequence of packets from broadcast
+        /// from the same device.
+        /// 
+        ///    DevAddr: 0028B946 
+        ///    NwkSKey: 2B7E151628AED2A6ABF7158809CF4F3C
+        ///    AppSKey: 2B7E151628AED2A6ABF7158809CF4F3C
+        ///    FRMPayload: 
+        ///      Packet 0: 323A313030  (decrypted)
+        ///      Packet 1: 3138353A313030 (decrypted)
+        ///      Packet 2: 3139323A313030 (decrypted)
+        ///    FCnt:
+        ///      Packet 0: 67
+        ///      Packet 1: 68
+        ///      Packet 2: 69
+
+* **Broadcast a verbatim packet.** This option allows the user to specify the complete text of the packet. The text starts with 24 hexidecimal digits, followed by a block of JSON parameters. Here's a sample packet:
+
+        0205DB00AA555A0000000101{"rxpk":[{ "tmst":2166390139,"chan":0,"rfch":1,"freq":868.100000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":9.5,"rssi":-24,"size":18,"data":"QEa5KADAQwAIwahYNa9zWAn1"}]}
+
+* **Blank Line.** Exits the application.
+
+Here's a sample transcript:
+
+~~~
+% PacketForwarderSimulator
+
+Welcome to the PacketForwarder Simulator
+Broadcasting to 127.0.0.1, port 1680.
+
+Enter verbatim packet text, a packet number in the range 0..2 or a blank line to exit.
+
+packet? 1
+  ... broadcasting pre-recorded packet 1.
+packet? 0205DB00AA555A0000000101{"rxpk":[{ "tmst":2166390139,"chan":0,"rfch":1,"freq":868.100000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":9.5,"rssi":-24,"size":18,"data":"QEa5KADAQwAIwahYNa9zWAn1"}]}
+  ... broadcasting verbatim packet
+packet?
+Press any key to continue . . .
+~~~

--- a/LoRaEngine/LoraTools/PacketForwarder.cs
+++ b/LoRaEngine/LoraTools/PacketForwarder.cs
@@ -34,5 +34,17 @@ namespace LoRaTools
         {
             m_client.Send(bytes, bytes.Length, m_endpoint);
         }
+
+
+        /// <summary>
+        /// Broadcasts a UDP packet corresponding to an IPacket.
+        /// The ip address and port are specified in the constructor.
+        /// </summary>
+        /// <param name="bytes"></param>
+        public void Send(IPacket packet)
+        {
+            var rawBytes = packet.GetRawWireBytes();
+            Send(rawBytes);
+        }
     }
 }

--- a/LoRaEngine/LoraTools/PacketForwarder.cs
+++ b/LoRaEngine/LoraTools/PacketForwarder.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using System.Net.Sockets;
+
+
+namespace LoRaTools
+{
+    /// <summary>
+    /// Helper class that broadcasts UDP packets.
+    /// Used to simulate a Semtech LoRaWAN packet forwarder device
+    /// in unit tests.
+    /// </summary>
+    public class PacketForwarder
+    {
+        IPEndPoint m_endpoint;
+        UdpClient m_client;
+
+        /// <summary>
+        /// Constructor is parameterized by ip address and port.
+        /// </summary>
+        /// <param name="ip">ip address to which packets will be broadcast</param>
+        /// <param name="port">port to which packets will be broadcast</param>
+        public PacketForwarder(string ip, int port)
+        {
+            m_endpoint = new IPEndPoint(IPAddress.Parse(ip), port);
+            m_client = new UdpClient();
+        }
+
+        /// <summary>
+        /// Broadcasts a UDP packet made up of the specified bytes.
+        /// The ip address and port are specified in the constructor.
+        /// </summary>
+        /// <param name="bytes"></param>
+        public void Send(byte[] bytes)
+        {
+            m_client.Send(bytes, bytes.Length, m_endpoint);
+        }
+    }
+}

--- a/LoRaEngine/LoraTools/Packets.cs
+++ b/LoRaEngine/LoraTools/Packets.cs
@@ -121,5 +121,10 @@ namespace LoRaTools
             }
             return new RecordedPacket(m_packets[n]);
         }
+
+        public static int GetPacketCount()
+        {
+            return m_packets.Length;
+        }
     }
 }

--- a/LoRaEngine/LoraTools/Packets.cs
+++ b/LoRaEngine/LoraTools/Packets.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Text.RegularExpressions;
 
 
 namespace LoRaTools
@@ -125,6 +126,30 @@ namespace LoRaTools
         public static int GetPacketCount()
         {
             return m_packets.Length;
+        }
+    }
+
+
+    public class PacketValidator
+    {
+        static Regex m_re;
+
+        static PacketValidator()
+        {
+            string pattern = @"\A[a-f|A-F|0-9]{24}\{.*\}\z";
+            m_re = new Regex(pattern);
+        }
+
+
+        /// <summary>
+        /// A packet passes this test if it starts with 24 hexidecimal
+        /// digits, followed by a block of text surrounded by {}.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public static bool IsLikelyValidLoRaWanPacket(string text)
+        {
+            return m_re.Matches(text).Count == 1;
         }
     }
 }

--- a/LoRaEngine/LoraTools/Packets.cs
+++ b/LoRaEngine/LoraTools/Packets.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Text;
+
+
+namespace LoRaTools
+{
+    /// <summary>
+    /// IPacket represents the raw byte representation of a LoRaWan device
+    /// packet. The interface mainly exists to facilitate tests that simulate
+    /// LoRaWan devices. Simulation is important for unit tests that run in
+    /// a CI environment.
+    /// </summary>
+    public interface IPacket
+    {
+        // Return the packet bytes as they would be received over the air.
+        byte[] GetRawWireBytes();
+    }
+
+
+    /// <summary>
+    /// RecordedPacket is an IPacket that is constructed from raw bytes
+    /// as received over the air.
+    /// </summary>
+    public class RecordedPacket : IPacket
+    {
+        byte[] m_rawBytes;
+
+        public RecordedPacket(string packet)
+        {
+            m_rawBytes = Encoding.UTF8.GetBytes(packet);
+        }
+
+        byte[] IPacket.GetRawWireBytes()
+        {
+            return m_rawBytes;
+        }
+    }
+
+
+    /// <summary>
+    /// SyntheticPacket is an IPacket that is synthesized from logical parts
+    /// like the device address, network key, application key, frameCounter,
+    /// and payload.
+    /// </summary>
+    public class SyntheticPacket : RecordedPacket
+    {
+        public SyntheticPacket(
+            int devAddr,
+            Int64 nwkskey,
+            Int64 appsKey,
+            Int16 frameCounter, 
+            byte [] payload)
+            : base(null)
+        {
+            // TODO: using constructor parameters, build and initialize
+            // m_rawBytes here.
+            
+            // TODO: consider adding methods that allow the specification of
+            // various JSON attributes like time, tmms, tmst, freq, etc.
+            // There are too many of these specify via constructor parameters,
+            // so the model would be
+            //    1. Constructor initializes JSON parameters to default values.
+            //    2. User then calls methods to specify new values for some items.
+            //    3. GetRawWireBytes() method computes bytes on demand, instead
+            //       relying on cached value.
+
+            throw new System.NotImplementedException("SyntheticPacket not implemented.");
+        }
+    }
+
+
+    /// <summary>
+    /// PrerecordedPackets provides a static method that returns one of a
+    /// number of pre-recorded packets, provided for testing purposes.
+    /// </summary>
+    public class PrerecordedPackets
+    {
+        static string[] m_packets;
+
+        static PrerecordedPackets()
+        {
+            m_packets = new string[]
+            {
+                "0205DB00AA555A0000000101{\"rxpk\":[{ \"tmst\":2166390139,\"chan\":0,\"rfch\":1,\"freq\":868.100000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":9.5,\"rssi\":-24,\"size\":18,\"data\":\"QEa5KADAQwAIwahYNa9zWAn1\"}]}",
+                "0205DB00AA555A0000000101{\"rxpk\":[{\"tmst\":2185426075,\"chan\":1,\"rfch\":1,\"freq\":868.300000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":9.5,\"rssi\":-21,\"size\":20,\"data\":\"QEa5KADARAAIK4BzkmhMRZOrOOk=\"}]}",
+                "0205DB00AA555A0000000101{\"rxpk\":[{\"tmst\":2195955763,\"chan\":2,\"rfch\":1,\"freq\":868.500000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":7.5,\"rssi\":-22,\"size\":20,\"data\":\"QEa5KADARQAIlxv5SG8raslJeKk=\"}]}"
+            };
+        }
+
+        /// <summary>
+        /// Returns the pre-recorded packet specified by parameter n.
+        /// 
+        /// Packets 0, 1, and 2 form a sequence of packets from broadcast
+        /// from the same device.
+        /// 
+        ///    DevAddr: 0028B946 
+        ///    NwkSKey: 2B7E151628AED2A6ABF7158809CF4F3C
+        ///    AppSKey: 2B7E151628AED2A6ABF7158809CF4F3C
+        ///    FRMPayload: 
+        ///      Packet 0: 323A313030  (decrypted)
+        ///      Packet 1: 3138353A313030 (decrypted)
+        ///      Packet 2: 3139323A313030 (decrypted)
+        ///    FCnt:
+        ///      Packet 0: 67
+        ///      Packet 1: 68
+        ///      Packet 2: 69
+        ///
+        /// Packets can be decoded with the following links:
+        ///    https://lorawan-packet-decoder-0ta6puiniaut.runkit.sh/?data=QEa5KADAQwAIwahYNa9zWAn1&nwkskey=2B7E151628AED2A6ABF7158809CF4F3C&appskey=2B7E151628AED2A6ABF7158809CF4F3C
+        ///    https://lorawan-packet-decoder-0ta6puiniaut.runkit.sh/?data=QEa5KADARAAIK4BzkmhMRZOrOOk%3D&nwkskey=2B7E151628AED2A6ABF7158809CF4F3C&appskey=2B7E151628AED2A6ABF7158809CF4F3C
+        ///    https://lorawan-packet-decoder-0ta6puiniaut.runkit.sh/?data=QEa5KADARQAIlxv5SG8raslJeKk%3D&nwkskey=2B7E151628AED2A6ABF7158809CF4F3C&appskey=2B7E151628AED2A6ABF7158809CF4F3C
+        ///
+        /// </summary>
+        /// <param name="n">Specifies the recorded packet to return. Current legal values are 0, 1, and 2.</param>
+        /// <returns>IPacket representing the recorded packet.</returns>
+        public static IPacket GetPacket(int n)
+        {
+            if (n < 0 || n >= m_packets.Length)
+            {
+                throw new System.ArgumentException("Packet number out of range.");
+            }
+            return new RecordedPacket(m_packets[n]);
+        }
+    }
+}


### PR DESCRIPTION
Refactored PacketForwarderSimulator. Allow functionality from the interactive tool is now available as library calls for automated tests.

Can now playback any of three recorded packets.
Can also send packets based on verbatim test (which might be redirected in from a file)

Added command line arguments and help messages.

See the README.md in LoRaEngine/DevTools/PacketForwarderSimulator/ for complete details.