### PR TITLE
First Generic implementation of the LoRa Message Parser/Builder

### DIFF
--- a/LoRaEngine/DevTools/LoRaWanManagerTest/LoRaWanManagerTest.csproj
+++ b/LoRaEngine/DevTools/LoRaWanManagerTest/LoRaWanManagerTest.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\LoraTools\LoRaTools.csproj" />
+    <ProjectReference Include="..\..\LoRaWan.NetworkServer\LoRaWan.NetworkServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
+++ b/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
@@ -4,6 +4,9 @@ using PacketManager;
 using System.Linq;
 using Newtonsoft.Json;
 using LoRaTools;
+using System.Net.Sockets;
+using System.Net;
+using LoRaWan.NetworkServer;
 
 namespace AESDemo
 {
@@ -24,6 +27,7 @@ namespace AESDemo
         }
         static void Main(string[] args)
         {
+            //Section testing different kind of decryption.
             byte[] leadingByte = StringToByteArray("0205DB00AA555A0000000101");
 
             string inputJson = "{\"rxpk\":[{\"tmst\":3121882787,\"chan\":2,\"rfch\":1,\"freq\":868.500000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":7.0,\"rssi\":-16,\"size\":20,\"data\":\"QEa5KACANwAIXiRAODD6gSCHMSk=\"}]}";
@@ -32,7 +36,7 @@ namespace AESDemo
             LoRaMessage message = new LoRaMessage(messageraw);
             Console.WriteLine("decrypted " + (message.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
             Console.WriteLine("mic is valid: " + message.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
-    
+
             // join message
             string joinInputJson = "{\"rxpk\":[{\"tmst\":286781788,\"chan\":0,\"rfch\":1,\"freq\":868.100000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF12BW125\",\"codr\":\"4/5\",\"lsnr\":11.0,\"rssi\":-17,\"size\":23,\"data\":\"AEZIZ25pc2lSj4gAAAAAer5VEV5aL4c=\"}]}";
 
@@ -43,14 +47,31 @@ namespace AESDemo
             //Console.WriteLine("decrypted " + (joinMessage.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
             Console.WriteLine("mic is valid: " + joinMessage.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
 
-            var ip = "127.0.0.1";
-            int port = 1682;
 
-            PacketForwarder p = new PacketForwarder(ip,port);
-          
-            LoRaPayloadJoinAccept joinAcceptPayload = new LoRaPayloadJoinAccept("FF08F5", "2B7E151628AED2A6ABF7158809CF4F3C");
-            p.Send(joinAcceptPayload.getFinalMessage());
 
+
+
+            ////section building up a low level message for the concentrator
+            // LoRaPayloadJoinAccept joinAcceptPayload = new LoRaPayloadJoinAccept("FF08F5", "2B7E151628AED2A6ABF7158809CF4F3C", StringToByteArray("00000000"));
+            //var tmp = joinAcceptPayload.getFinalMessage(Encoding.Default.GetBytes("1234"));
+            // Console.WriteLine(Convert.ToBase64String(tmp));
+            // listener.Send(tmp, tmp.Length);
+
+
+
+
+            ////Section running the server to monitor LoRaWan messages, working for upling msg
+            //UdpServer udp = new UdpServer();
+            // udp.RunServer(true);
+            //Console.Read();
+
+
+            ////Section testing correct build up of message, NOT WORKING
+            //LoRaPayloadJoinAccept joinAccept = new LoRaPayloadJoinAccept("FF08F5", "2B7E151628AED2A6ABF7158809CF4F3C", StringToByteArray("00000000"));
+            //LoRaMessage message = new LoRaMessage(joinAccept, LoRaMessageType.JoinAccept, new byte[] { 0x01 });
+            //Console.Write(message.loraMetadata.rawB64data);
+            //Console.Write(message.physicalPayload);
+            //Console.Read();
             Console.Read();
             Console.Read();
         }

--- a/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
+++ b/LoRaEngine/DevTools/LoRaWanManagerTest/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using PacketManager;
 using System.Linq;
 using Newtonsoft.Json;
+using LoRaTools;
 
 namespace AESDemo
 {
@@ -24,14 +25,36 @@ namespace AESDemo
         static void Main(string[] args)
         {
             byte[] leadingByte = StringToByteArray("0205DB00AA555A0000000101");
-            
+
             string inputJson = "{\"rxpk\":[{\"tmst\":3121882787,\"chan\":2,\"rfch\":1,\"freq\":868.500000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF7BW125\",\"codr\":\"4/5\",\"lsnr\":7.0,\"rssi\":-16,\"size\":20,\"data\":\"QEa5KACANwAIXiRAODD6gSCHMSk=\"}]}";
-            
+
             byte[] messageraw = leadingByte.Concat(Encoding.Default.GetBytes(inputJson)).ToArray();
             LoRaMessage message = new LoRaMessage(messageraw);
-            Console.WriteLine("decrypted "+(message.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
-            Console.WriteLine("mic is valid: "+message.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
+            Console.WriteLine("decrypted " + (message.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
+            Console.WriteLine("mic is valid: " + message.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
+    
+            // join message
+            string joinInputJson = "{\"rxpk\":[{\"tmst\":286781788,\"chan\":0,\"rfch\":1,\"freq\":868.100000,\"stat\":1,\"modu\":\"LORA\",\"datr\":\"SF12BW125\",\"codr\":\"4/5\",\"lsnr\":11.0,\"rssi\":-17,\"size\":23,\"data\":\"AEZIZ25pc2lSj4gAAAAAer5VEV5aL4c=\"}]}";
+
+            //byte[] joinBytes = StringToByteArray("00DC0000D07ED5B3701E6FEDF57CEEAF00C886030AF2C9");
+
+            byte[] messageJoinraw = leadingByte.Concat(Encoding.Default.GetBytes(joinInputJson)).ToArray();
+            LoRaMessage joinMessage = new LoRaMessage(messageJoinraw);
+            //Console.WriteLine("decrypted " + (joinMessage.DecryptPayload("2B7E151628AED2A6ABF7158809CF4F3C")));
+            Console.WriteLine("mic is valid: " + joinMessage.CheckMic("2B7E151628AED2A6ABF7158809CF4F3C"));
+
+            var ip = "127.0.0.1";
+            int port = 1682;
+
+            PacketForwarder p = new PacketForwarder(ip,port);
+          
+            LoRaPayloadJoinAccept joinAcceptPayload = new LoRaPayloadJoinAccept("FF08F5", "2B7E151628AED2A6ABF7158809CF4F3C");
+            p.Send(joinAcceptPayload.getFinalMessage());
+
+            Console.Read();
             Console.Read();
         }
     }
+
+
 }

--- a/LoRaEngine/LoRaWan.NetworkServer/UdpServer.cs
+++ b/LoRaEngine/LoRaWan.NetworkServer/UdpServer.cs
@@ -15,7 +15,7 @@ namespace LoRaWan.NetworkServer
         const int PORT = 1680;
         int retryCount = 0;
 
-        string connectionString;
+        string connectionString = "HostName=testiotmikou.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=h2XcVzgOtQqAQgRA8pV6fUoGHIh9O2vFdfSsqzYD8b0=";
         bool udpListenerRunning = false;
         UdpClient udpClient = null;
         DeviceClient ioTHubModuleClient = null;
@@ -112,7 +112,7 @@ namespace LoRaWan.NetworkServer
             catch(Exception ex)
             {
                 Console.WriteLine($"Initialization failed with error: {ex.Message}.\nWaiting for update desired property 'connstr'.");
-                connectionString = null;
+                //connectionString = null;
             }
         }
 

--- a/LoRaEngine/LoraTools/LoraMessage.cs
+++ b/LoRaEngine/LoraTools/LoraMessage.cs
@@ -10,7 +10,8 @@ using System.Text;
 
 namespace PacketManager
 {
-    public class LoRaPayloadMessage
+    #region LoRaPayloadWrapper
+    public abstract class LoRaPayloadWrapper
     {
         /// <summary>
         /// raw byte of the message
@@ -21,6 +22,178 @@ namespace PacketManager
         /// </summary>
         public byte[] mhdr;
 
+        /// <summary>
+        /// Message Integrity Code
+        /// </summary>
+        public byte[] mic;
+
+
+        /// <summary>
+        /// Wrapper of a LoRa message, consisting of the MIC and MHDR, common to all LoRa messages
+        /// This is used for uplink / decoding
+        /// </summary>
+        /// <param name="inputMessage"></param>
+        public  LoRaPayloadWrapper(byte[] inputMessage)
+        {
+            rawMessage = inputMessage;
+            //get the mhdr
+            byte[] mhdr = new byte[1];
+            Array.Copy(inputMessage, 0, mhdr, 0, 1);
+            this.mhdr = mhdr;
+
+            //MIC 4 last bytes
+            byte[] mic = new byte[4];
+            Array.Copy(inputMessage, inputMessage.Length - 4, mic, 0, 4);
+            this.mic = mic;
+        }
+
+        /// <summary>
+        /// This is used for downlink, The field will be computed at message creation
+        /// </summary>
+        public LoRaPayloadWrapper()
+        {
+           
+        }
+
+
+
+    }
+    #endregion
+
+    #region LoRaPayloadDownlinkWrapper
+    public abstract class LoRaPayloadDownlinkWrapper:LoRaPayloadWrapper
+    {
+
+        /// <summary>
+        /// Wrapper of a LoRa message, consisting of the MIC and MHDR, common to all LoRa messages
+        /// This is used for uplink / decoding
+        /// </summary>
+        /// <param name="inputMessage"></param>
+        public LoRaPayloadDownlinkWrapper(byte[] inputMessage):base(inputMessage)
+        {
+    
+        }
+
+        /// <summary>
+        /// This is used for downlink, when we need to compute those fields
+        /// </summary>
+        public LoRaPayloadDownlinkWrapper()
+        {
+
+        }
+
+        public abstract string EncryptPayload(string appSkey);
+
+        public abstract byte[] CalculateMic(string nwskey);
+
+    }
+    #endregion
+
+
+    #region LoRaPayloadDownlinkWrapper
+    public abstract class LoRaPayloadUplinkWrapper : LoRaPayloadWrapper
+    {
+    
+
+        /// <summary>
+        /// Wrapper of a LoRa message, consisting of the MIC and MHDR, common to all LoRa messages
+        /// This is used for uplink / decoding
+        /// </summary>
+        /// <param name="inputMessage"></param>
+        public LoRaPayloadUplinkWrapper(byte[] inputMessage) : base(inputMessage)
+        {
+
+        }
+
+        /// <summary>
+        /// This is used for downlink, when we need to compute those fields
+        /// </summary>
+        public LoRaPayloadUplinkWrapper()
+        {
+
+        }
+
+        public abstract string DecryptPayload(string appSkey);
+
+        public abstract bool CheckMic(string nwskey);
+
+    }
+    #endregion
+
+
+    #region LoRaPayloadJoinRequest
+    public class LoRaPayloadJoinRequest : LoRaPayloadUplinkWrapper
+    {
+
+        //aka JoinEUI
+        public byte[] appEUI;
+        public byte[] devEUI;
+        public byte[] devNonce;
+
+        public LoRaPayloadJoinRequest(byte[] inputMessage) : base(inputMessage)
+        {
+            //TODO implement a table to store a mapping with joinEUI-DevNonce
+
+            var inputmsgstr = BitConverter.ToString(inputMessage);
+            //get the joinEUI field
+            appEUI = new byte[8];
+            Array.Copy(inputMessage, 1, appEUI, 0, 8);
+  
+            var appEUIStr = BitConverter.ToString(appEUI);
+            //get the DevEUI
+            devEUI = new byte[8];
+            Array.Copy(inputMessage, 9, devEUI, 0, 8);
+  
+            var devEUIStr = BitConverter.ToString(devEUI);
+            //get the DevNonce
+            devNonce = new byte[2];
+            Array.Copy(inputMessage, 17, devNonce, 0, 2);
+       
+            var devNonceStr = BitConverter.ToString(devNonce);
+
+        }
+
+        public override bool CheckMic(string AppKey)
+        {
+            //appEUI = StringToByteArray("526973696E674846");
+            IMac mac = MacUtilities.GetMac("AESCMAC");
+           
+            KeyParameter key = new KeyParameter(StringToByteArray(AppKey));
+            mac.Init(key);
+            var appEUIStr = BitConverter.ToString(appEUI);
+            var devEUIStr = BitConverter.ToString(devEUI);
+            var devNonceStr = BitConverter.ToString(devNonce);
+
+            var micstr = BitConverter.ToString(mic);
+
+            var algoinput = mhdr.Concat(appEUI).Concat(devEUI).Concat(devNonce).ToArray();
+            byte[] result = new byte[19];
+            mac.BlockUpdate(algoinput, 0, algoinput.Length);
+            result = MacUtilities.DoFinal(mac);
+            var resStr = BitConverter.ToString(result);
+            return mic.SequenceEqual(result.Take(4).ToArray());
+        }
+
+        public override string DecryptPayload(string appSkey)
+        {
+            throw new NotImplementedException("The payload is not encrypted in case of a join message");
+        }
+
+        private byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+    }
+    #endregion
+    #region LoRaPayloadUplink
+    /// <summary>
+    /// the body of an Uplink message
+    /// </summary>
+    public class LoRaPayloadUplink : LoRaPayloadUplinkWrapper
+    {
         /// <summary>
         /// Device MAC Address
         /// </summary>
@@ -45,10 +218,7 @@ namespace PacketManager
         /// MAC Frame Payload Encryption 
         /// </summary>
         public byte[] frmpayload;
-        /// <summary>
-        /// Message Integrity Code
-        /// </summary>
-        public byte[] mic;
+    
 
         /// <summary>
         /// get message direction
@@ -58,13 +228,9 @@ namespace PacketManager
 
 
         /// <param name="inputMessage"></param>
-        public LoRaPayloadMessage(byte[] inputMessage)
+        public LoRaPayloadUplink(byte[] inputMessage) : base(inputMessage)
         {
-            rawMessage = inputMessage;
-            //get the mhdr
-            byte[] mhdr = new byte[1];
-            Array.Copy(inputMessage, 0, mhdr, 0, 1);
-            this.mhdr = mhdr;
+          
             //get direction
             var checkDir=(mhdr[0] >> 5);
             //in this case the payload is not downlink of our type
@@ -111,14 +277,245 @@ namespace PacketManager
             Array.Copy(inputMessage, 9 + foptsSize, FRMPayload, 0, inputMessage.Length - 9 - 4 - foptsSize);
             this.frmpayload = FRMPayload;
 
-            //MIC 4 last bytes
-            byte[] mic = new byte[4];
-            Array.Copy(inputMessage, inputMessage.Length - 4, mic, 0, 4);
-            this.mic = mic;
+        }
+
+        /// <summary>
+        /// Method to check if the mic is valid
+        /// </summary>
+        /// <param name="nwskey">the network security key</param>
+        /// <returns></returns>
+        public override bool CheckMic(string nwskey)
+        {
+            IMac mac = MacUtilities.GetMac("AESCMAC");
+            KeyParameter key = new KeyParameter(StringToByteArray(nwskey));
+            mac.Init(key);
+            byte[] block = { 0x49, 0x00, 0x00, 0x00, 0x00, (byte)direction, (byte)(devAddr[3]), (byte)(devAddr[2]), (byte)(devAddr[1]),
+                (byte)(devAddr[0]),  fcnt[0] , fcnt[1],0x00, 0x00, 0x00, (byte)(rawMessage.Length-4) };
+            var algoinput = block.Concat(rawMessage.Take(rawMessage.Length - 4)).ToArray();
+            byte[] result = new byte[16];
+            mac.BlockUpdate(algoinput, 0, algoinput.Length);
+            result = MacUtilities.DoFinal(mac);
+            return mic.SequenceEqual(result.Take(4).ToArray());
+        }
+
+        /// <summary>
+        /// src https://github.com/jieter/python-lora/blob/master/lora/crypto.py
+        /// </summary>
+        public override string DecryptPayload(string appSkey)
+        {
+            AesEngine aesEngine = new AesEngine();
+            aesEngine.Init(true, new KeyParameter(StringToByteArray(appSkey)));
+
+            byte[] aBlock = { 0x01, 0x00, 0x00, 0x00, 0x00, (byte)direction, (byte)(devAddr[3]), (byte)(devAddr[2]), (byte)(devAddr[1]),
+                (byte)(devAddr[0]),(byte)(fcnt[0]),(byte)(fcnt[1]),  0x00 , 0x00, 0x00, 0x00 };
+
+            byte[] sBlock = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            int size = frmpayload.Length;
+            byte[] decrypted = new byte[size];
+            byte bufferIndex = 0;
+            short ctr = 1;
+            int i;
+            while (size >= 16)
+            {
+                aBlock[15] = (byte)((ctr) & 0xFF);
+                ctr++;
+                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
+                for (i = 0; i < 16; i++)
+                {
+                    decrypted[bufferIndex + i] = (byte)(frmpayload[bufferIndex + i] ^ sBlock[i]);
+                }
+                size -= 16;
+                bufferIndex += 16;
+            }
+            if (size > 0)
+            {
+                aBlock[15] = (byte)((ctr) & 0xFF);
+                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
+                for (i = 0; i < size; i++)
+                {
+                    decrypted[bufferIndex + i] = (byte)(frmpayload[bufferIndex + i] ^ sBlock[i]);
+                }
+            }
+            return Encoding.Default.GetString(decrypted);
+        }
+
+        private byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+    }
+    #endregion
+    #region LoRaPayloadJoinAccept
+    public class LoRaPayloadJoinAccept : LoRaPayloadDownlinkWrapper
+    {
+        /// <summary>
+        /// Server Nonce aka JoinNonce
+        /// </summary>
+        public byte[] appNonce;
+
+        /// <summary>
+        /// Device home network aka Home_NetId
+        /// </summary>
+        public byte[] netID;
+
+        /// <summary>
+        /// Assigned Dev Address
+        /// </summary>
+        public byte[] devAddr;
+
+        /// <summary>
+        /// DLSettings
+        /// </summary>
+        public byte[] dlSettings;
+
+        /// <summary>
+        /// RxDelay
+        /// </summary>
+        public byte[] rxDelay;
+
+        /// <summary>
+        /// CFList / Optional
+        /// </summary>
+        public byte[] cfList;
+
+        /// <summary>
+        /// Frame Counter
+        /// </summary>
+        public byte[] fcnt;
+
+        public LoRaPayloadJoinAccept(string _netId,string appKey) 
+        {
+            appNonce = new byte[3];
+            netID = new byte[3];
+            devAddr = new byte[4];
+            dlSettings = new byte[1];
+            rxDelay = new byte[1];
+            cfList = null ;
+            //set payload Wrapper fields
+            mhdr = new byte[1];
+            appNonce = BitConverter.GetBytes(0);
+            netID = StringToByteArray(_netId);
+            devAddr = StringToByteArray("00000000");
+            //default param 869.525 MHz / DR0 (SF12, 125 kHz)  
+            dlSettings = BitConverter.GetBytes(0);
+            //cfList = StringToByteArray("1F84B9E25D9C4115F02EEA0B3DD3E20B");
+            cfList = null;
+            //todo implement a fctn? Could be error reason
+            fcnt = BitConverter.GetBytes(0x00);
+            mhdr = BitConverter.GetBytes(0x20);
+            CalculateMic(appKey);
+            EncryptPayload(appKey);
+        }
+
+        private byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+
+        public override string EncryptPayload(string appSkey)
+        {
+            //return null;
+            AesEngine aesEngine = new AesEngine();
+            aesEngine.Init(true, new KeyParameter(StringToByteArray(appSkey)));
+            byte[] rfu = new byte[1];
+            rfu[0] = 0x0;
+            //downlink direction
+            byte direction = 0x01;
+            byte[] aBlock = { 0x01, 0x00, 0x00, 0x00, 0x00, direction, (byte)(devAddr[3]), (byte)(devAddr[2]), (byte)(devAddr[1]),
+                (byte)(devAddr[0]),(byte)(fcnt[0]),(byte)(fcnt[1]),  0x00 , 0x00, 0x00, 0x00 };
+            byte[] frmpayload;
+            if (cfList!=null)
+                frmpayload = appNonce.Concat(netID).Concat(devAddr).Concat(rfu).Concat(rxDelay).Concat(cfList).Concat(mic).ToArray();
+            else
+                frmpayload = appNonce.Concat(netID).Concat(devAddr).Concat(rfu).Concat(rxDelay).Concat(mic).ToArray();
+
+            byte[] sBlock = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            int size = 12 +( cfList!=null?cfList.Length:0);
+            byte[] decrypted = new byte[size];
+            byte bufferIndex = 0;
+            short ctr = 1;
+            int i;
+            while (size >= 16)
+            {
+                aBlock[15] = (byte)((ctr) & 0xFF);
+                ctr++;
+                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
+                for (i = 0; i < 16; i++)
+                {
+                    decrypted[bufferIndex + i] = (byte)(frmpayload[bufferIndex + i] ^ sBlock[i]);
+                }
+                size -= 16;
+                bufferIndex += 16;
+            }
+            if (size > 0)
+            {
+                aBlock[15] = (byte)((ctr) & 0xFF);
+                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
+                for (i = 0; i < size; i++)
+                {
+                    decrypted[bufferIndex + i] = (byte)(frmpayload[bufferIndex + i] ^ sBlock[i]);
+                }
+            }
+            rawMessage = decrypted;
+            return Encoding.Default.GetString(decrypted);
+        }
+
+        public override byte[] CalculateMic(string appKey)
+        {
+            IMac mac = MacUtilities.GetMac("AESCMAC");
+            KeyParameter key = new KeyParameter(StringToByteArray(appKey));
+            mac.Init(key);
+            byte[] rfu = new byte[1];
+            rfu[0] = 0x0;
+            var algoinput = mhdr.Concat(appNonce).Concat(netID).Concat(devAddr).Concat(rfu).Concat(rxDelay).ToArray();
+            if (cfList != null)
+                algoinput = algoinput.Concat(cfList).ToArray();
+                
+                
+            byte[] result = new byte[16];
+            mac.BlockUpdate(algoinput, 0, algoinput.Length);
+            result = MacUtilities.DoFinal(mac);
+            mic = result.Take(4).ToArray();
+            return mic;
+        }
+
+        public byte[] getFinalMessage()
+        {
+            
+            var downlinkmsg = new DownlinkPktFwdMessage(Convert.ToBase64String(rawMessage));
+            return Encoding.Default.GetBytes(JsonConvert.SerializeObject(downlinkmsg));
         }
     }
 
+    public class DownlinkPktFwdMessage
+    {
+        public Txpk txpk;
 
+        public DownlinkPktFwdMessage(string _data)
+        {
+            txpk = new Txpk()
+            {
+                imme = true,
+                data = _data,
+                size = (uint)(_data.Length * 3 / 4)
+            };
+        }
+    }
+
+    public class Txpk
+    {
+        public bool imme;
+        public string data;
+        public uint size; 
+    }
+    #endregion
+    #region LoRaMetada
     public class LoRaMetada
     {
         public byte[] gatewayMacAddress { get; set; }
@@ -162,90 +559,72 @@ namespace PacketManager
             devAddr = BitConverter.ToString(addrbytes);
         }
     }
-   
+    #endregion
     /// <summary>
     /// class exposing usefull message stuff
     /// </summary>
     public class LoRaMessage
     {
-        public LoRaPayloadMessage payloadMessage;
+        public LoRaPayloadWrapper payloadMessage;
         public LoRaMetada lorametadata;
 
+
+        /// <summary>
+        /// This contructor is used in case of uplink message, hence we don't know the message type yet
+        /// </summary>
+        /// <param name="inputMessage"></param>
         public LoRaMessage(byte[] inputMessage)
         {
             lorametadata = new LoRaMetada(inputMessage);
-            //set up the parts of the raw message           
-            payloadMessage = new LoRaPayloadMessage(Convert.FromBase64String(lorametadata.rawB64data));
+            //set up the parts of the raw message   
+            byte[] convertedInputMessage = Convert.FromBase64String(lorametadata.rawB64data);
+            var messageType = convertedInputMessage[0]>>5;
+
+            //Uplink Message
+            if (messageType == 2)
+               payloadMessage = new LoRaPayloadUplink(convertedInputMessage);
+            if (messageType == 0)
+                payloadMessage = new LoRaPayloadJoinRequest(convertedInputMessage);
 
         }
 
         /// <summary>
-        /// Method to check if the mic is valid
+        /// This contructor is used in case of downlink message
         /// </summary>
-        /// <param name="nwskey">the network security key</param>
-        /// <returns></returns>
+        /// <param name="inputMessage"></param>
+        /// <param name="type">
+        /// 0 = Join Request
+        /// 1 = Join Accept
+        /// 2 = Unconfirmed Data up
+        /// 3 = Unconfirmed Data down
+        /// 4 = Confirmed Data up
+        /// 5 = Confirmed Data down
+        /// 6 = Rejoin Request</param>
+        public LoRaMessage(byte[] messagePayload, int type)
+        {
+            //construct a Join Accept Message
+            if(type == 1)
+            {
+
+            }
+         
+
+        }
+
         public bool CheckMic(string nwskey)
         {
-            IMac mac = MacUtilities.GetMac("AESCMAC");
-            KeyParameter key = new KeyParameter(StringToByteArray(nwskey));
-            mac.Init(key);
-            byte[] block = { 0x49, 0x00, 0x00, 0x00, 0x00, (byte)this.payloadMessage.direction, (byte)(this.payloadMessage.devAddr[3]), (byte)(payloadMessage.devAddr[2]), (byte)(payloadMessage.devAddr[1]),
-                (byte)(payloadMessage.devAddr[0]),  this.payloadMessage.fcnt[0] , this.payloadMessage.fcnt[1],0x00, 0x00, 0x00, (byte)(this.payloadMessage.rawMessage.Length-4) };
-            var algoinput = block.Concat(this.payloadMessage.rawMessage.Take(this.payloadMessage.rawMessage.Length - 4)).ToArray();
-            byte[] result = new byte[16];
-            mac.BlockUpdate(algoinput, 0, algoinput.Length);
-            result = MacUtilities.DoFinal(mac);
-            return this.payloadMessage.mic.SequenceEqual(result.Take(4).ToArray());
+            return ((LoRaPayloadUplinkWrapper)payloadMessage).CheckMic(nwskey);
         }
 
-        /// <summary>
-        /// src https://github.com/jieter/python-lora/blob/master/lora/crypto.py
-        /// </summary>
-        public string DecryptPayload(string appSkey)
+        public  string DecryptPayload(string appSkey)
         {
-            AesEngine aesEngine = new AesEngine();
-            aesEngine.Init(true, new KeyParameter(StringToByteArray(appSkey)));
-
-            byte[] aBlock = { 0x01, 0x00, 0x00, 0x00, 0x00, (byte)this.payloadMessage.direction, (byte)(payloadMessage.devAddr[3]), (byte)(payloadMessage.devAddr[2]), (byte)(payloadMessage.devAddr[1]),
-                (byte)(payloadMessage.devAddr[0]),(byte)(payloadMessage.fcnt[0]),(byte)(payloadMessage.fcnt[1]),  0x00 , 0x00, 0x00, 0x00 };
-
-            byte[] sBlock = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-            int size = payloadMessage.frmpayload.Length;
-            byte[] decrypted = new byte[size];
-            byte bufferIndex = 0;
-            short ctr = 1;
-            int i;
-            while (size >= 16)
-            {
-                aBlock[15] = (byte)((ctr) & 0xFF);
-                ctr++;
-                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
-                for (i = 0; i < 16; i++)
-                {
-                    decrypted[bufferIndex + i] = (byte)(payloadMessage.frmpayload[bufferIndex + i] ^ sBlock[i]);
-                }
-                size -= 16;
-                bufferIndex += 16;
-            }
-            if (size > 0)
-            {
-                aBlock[15] = (byte)((ctr) & 0xFF);
-                aesEngine.ProcessBlock(aBlock, 0, sBlock, 0);
-                for (i = 0; i < size; i++)
-                {
-                    decrypted[bufferIndex + i] = (byte)(payloadMessage.frmpayload[bufferIndex + i] ^ sBlock[i]);
-                }
-            }
-            this.lorametadata.decodedData = Encoding.Default.GetString(decrypted);
-            return Encoding.Default.GetString(decrypted);
+            var retValue = ((LoRaPayloadUplinkWrapper)payloadMessage).DecryptPayload(appSkey);
+            lorametadata.decodedData = retValue;
+            return retValue;
         }
 
-        private byte[] StringToByteArray(string hex)
-        {
-            return Enumerable.Range(0, hex.Length)
-                             .Where(x => x % 2 == 0)
-                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
-                             .ToArray();
-        }
+
     }
+
+ 
 }


### PR DESCRIPTION
This is a Work In Progress PR, to keep rest of team updated on changes on the LoRa library implementation progress. Non working items detailed here below. 

Added implementation of 

- Concentrator frames parsing/building
- Downlink & Uplink messages with path
- First Draft of OTAA (non working) #10 
- Changed the LoRa Server to adapt to new architecture.

Not working:
- MIC / Encryption on Downlink currently faulty.
- Missing LoRa server part for OTAA (save nonce, keep device counter,..) #34 
- Missing LoRa server part for Downlink Message (Implementated but not yet implemented)

How to Test:
- DevTools/LoRaWanManagerTest/Program.cs contains some (fairly basic) test cases. Planning to move to a more structured test library with more systematic testing in a future PR. #8 

To be discussed:
- Split the LoRaMessage library into multiple files. 
- Refactoring of the LoRaMessage library.
- How to handle key/session management on the Lorawan Server Side. #34 


